### PR TITLE
Allow further attach options for debugging.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ue-python",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ue-python",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,16 +57,33 @@
     "configuration": [
       {
         "properties": {
-          "ue-python.debug.port": {
+          "ue-python.strictPort": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Prevent this extension from automatically finding a free port if a port assigned in the config is busy.",
+            "scope": "resource"
+          }
+        }
+      },
+      {
+        "title": "Attach",
+        "properties": {
+          "ue-python.attach.port": {
             "type": "number",
             "default": 6868,
             "description": "Port to use for the debugpy server when attaching VS Code to Unreal",
             "scope": "resource"
           },
-          "ue-python.strictPort": {
+          "ue-python.attach.justMyCode": {
             "type": "boolean",
-            "default": false,
-            "markdownDescription": "Prevent this extension from automatically finding a free port if a port assigned in the config is busy.",
+            "default": true,
+            "description": "Enable or disable Just My Code when attaching to Unreal Engine",
+            "scope": "resource"
+          },
+          "ue-python.attach.showOutput": {
+            "type": "boolean",
+            "default": true,
+            "description": "Display the output log when attaching to Unreal Engine",
             "scope": "resource"
           }
         }


### PR DESCRIPTION
Changed the attach script launching of the debug session, to use the `attach` configuration settings.
Allowing for more settings to be passed to the launch of the debug session.

Kept the added attach parameters to be `true` by default. So current usability isn't affected, but can be better modied from settings. Not many attach params but more can be added if needed.


---
Closes #23